### PR TITLE
Fixed bug with unicode characters in password.

### DIFF
--- a/swish/provider/SessionFactory.hpp
+++ b/swish/provider/SessionFactory.hpp
@@ -41,6 +41,7 @@
 #include <winerror.h>  // HRESULT
 
 #include <memory>      // auto_ptr
+#include <string>
 
 struct ISftpConsumer;
 
@@ -56,18 +57,18 @@ private:
         PCWSTR pwszHost, CSession& session, __in ISftpConsumer *pConsumer);
 
     static void _AuthenticateUser(
-        const wchar_t* pwszUser, CSession& session, 
+        PCWSTR pwszUser, CSession& session, 
         __in ISftpConsumer* pConsumer);
 
     static HRESULT _PasswordAuthentication(
-        const char* szUsername, CSession& session, 
+        const std::string& utf8_username, CSession& session, 
         __in ISftpConsumer* pConsumer);
 
     static HRESULT _KeyboardInteractiveAuthentication(
-        const char*  szUsername, CSession& session, 
+        const std::string& utf8_username, CSession& session, 
         __in ISftpConsumer* pConsumer);
 
     static HRESULT _PublicKeyAuthentication(
-        const char*  szUsername, CSession& session, 
+        const std::string& utf8_username, CSession& session, 
         __in ISftpConsumer* pConsumer);
 };


### PR DESCRIPTION
We weren't converting the username and password to UTF-8 and, instead, used the local Windows codepage.  SSH requires that they be encoded as UTF-8, so users that tried to use a password with non-ASCII characters in could not log in.

Fixes #213.
